### PR TITLE
refactor : 백엔드 변경사항에 맞게 DTO 변경

### DIFF
--- a/apps/wiki/apis/index.ts
+++ b/apps/wiki/apis/index.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
-import { ERROR, TOKEN } from "@/constants";
-import { Storage } from "@/storage";
-import { refreshToken } from "./header";
+import { ERROR } from "@/constants";
+import { refresh } from "@/services/auth/auth.api";
 
 export const http = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
@@ -23,9 +22,3 @@ http.interceptors.response.use(
     return Promise.reject(error);
   },
 );
-
-const refresh = async () => {
-  const { data } = await http.put("/auth/refresh/access", null, refreshToken());
-  Storage.setItem(TOKEN.ACCESS, data.accessToken);
-  return data.accessToken;
-};

--- a/apps/wiki/app/history/[title]/History.tsx
+++ b/apps/wiki/app/history/[title]/History.tsx
@@ -10,26 +10,25 @@ import * as styles from "./style.css";
 
 const History = ({ title }: { title: string }) => {
   const { formatDate } = useDate();
-  const { data: historyList } = useSuspenseQuery(historyQuery.list(title));
-  const decodeTitle = decodeURI(title);
+  const { data: history } = useSuspenseQuery(historyQuery.list(title));
 
   return (
     <Suspense>
-      <Container title={decodeTitle} docsType={decodeTitle}>
-        {historyList.versionDocsResponseDto.map((history) => (
+      <Container title={history.title} docsType={history.title}>
+        {history.versionDocsResponseDto.map((docsHistory) => (
           <Link
-            href={`/history/${decodeTitle}/detail/${history.index}`}
+            href={`/history/${history.title}/detail/${docsHistory.index}`}
             className={styles.historyBox}
-            key={String(history.thisVersionCreatedAt)}
+            key={String(docsHistory.thisVersionCreatedAt)}
           >
             <hgroup className={styles.hgroup}>
-              <h1 className={styles.historyId}>#{history.index}</h1>
+              <h1 className={styles.historyId}>#{docsHistory.index}</h1>
               <time className={styles.createdAt}>
                 편집일 ·&nbsp;
-                {formatDate(history.thisVersionCreatedAt)}
+                {formatDate(docsHistory.thisVersionCreatedAt)}
               </time>
             </hgroup>
-            <span className={styles.author}>작성자 ·&nbsp;{history.nickName}</span>
+            <span className={styles.author}>작성자 ·&nbsp;{docsHistory.nickName}</span>
           </Link>
         ))}
       </Container>

--- a/apps/wiki/app/history/[title]/History.tsx
+++ b/apps/wiki/app/history/[title]/History.tsx
@@ -14,7 +14,7 @@ const History = ({ title }: { title: string }) => {
 
   return (
     <Suspense>
-      <Container title={history.title} docsType={history.title}>
+      <Container title={history.title} docsType={history.docsType}>
         {history.versionDocsResponseDto.map((docsHistory) => (
           <Link
             href={`/history/${history.title}/detail/${docsHistory.index}`}

--- a/apps/wiki/components/Popular/Popular.tsx
+++ b/apps/wiki/components/Popular/Popular.tsx
@@ -24,7 +24,7 @@ const Popular = () => {
     >
       <header className={styles.titleBox}>인기</header>
       <ul className={styles.docsList}>
-        {popularList.slice(0, 10).map((popular, index) => (
+        {popularList.map((popular, index) => (
           <Link
             href={`/docs/${popular.title}`}
             className={styles.docsListItem[containerStatus]}

--- a/apps/wiki/services/auth/auth.api.ts
+++ b/apps/wiki/services/auth/auth.api.ts
@@ -1,15 +1,20 @@
 import { http } from "@/apis";
+import { refreshToken } from "@/apis/header";
 import { TOKEN } from "@/constants";
 import { Storage } from "@/storage";
 
-export const requestLogin = async (authCode: string) => {
-  const { data } = await http.post("/auth/oauth/bsm", null, { headers: { authCode } });
+export const refresh = async () => {
+  const { data } = await http.put("/auth/refresh/access", null, refreshToken());
+  Storage.setItem(TOKEN.ACCESS, data.accessToken);
+  return data.accessToken;
+};
+
+export const requestLogin = async (accessToken: string) => {
+  const { data } = await http.post("/auth/oauth/bsm", { accessToken });
   return data;
 };
 
 export const requestLogout = async () => {
-  const { data } = await http.delete("/auth/bsm/logout", {
-    headers: { RefreshToken: Storage.getItem(TOKEN.REFRESH) },
-  });
+  const { data } = await http.delete("/auth/bsm/logout", refreshToken());
   return data;
 };

--- a/apps/wiki/services/docs/docs.api.ts
+++ b/apps/wiki/services/docs/docs.api.ts
@@ -27,7 +27,7 @@ export const getLastModifiedDocsList = async (page: number) => {
 };
 
 export const requestCreateDocs = async (docs: CreateDocsType) => {
-  const { data } = await http.post("/docs/create", docs, authorization());
+  const { data } = await http.post("/docs", docs, authorization());
   return data;
 };
 
@@ -43,7 +43,7 @@ export const requestUpdateDocs = async ({
 };
 
 export const requestDeleteDocs = async (id: number) => {
-  const { data } = await http.delete(`/docs/delete/${id}`, authorization());
+  const { data } = await http.delete(`/docs/${id}`, authorization());
   return data;
 };
 

--- a/apps/wiki/services/history/history.query.ts
+++ b/apps/wiki/services/history/history.query.ts
@@ -1,10 +1,10 @@
 import { queryOptions } from "@tanstack/react-query";
-import { HistoryType } from "@/types";
+import { HistoryListType } from "@/types";
 import { getHistoryDetail, getHistoryList } from "./history.api";
 
 export const historyQuery = {
   list: <Title extends string>(title: Title) =>
-    queryOptions<{ versionDocsResponseDto: Array<HistoryType> }>({
+    queryOptions<HistoryListType>({
       queryKey: ["query.historyList", title],
       queryFn: () => getHistoryList(title),
     }),

--- a/apps/wiki/services/user/user.api.ts
+++ b/apps/wiki/services/user/user.api.ts
@@ -7,7 +7,7 @@ export const getMyInformation = async () => {
 };
 
 export const getUserById = async (id: number) => {
-  const { data } = await http.get(`/user/id/${id}`);
+  const { data } = await http.get(`/user/${id}`);
   return data;
 };
 

--- a/apps/wiki/types/historyList.interface.ts
+++ b/apps/wiki/types/historyList.interface.ts
@@ -1,0 +1,7 @@
+import { HistoryType } from ".";
+
+export default interface HistoryListType {
+  versionDocsResponseDto: Array<HistoryType>;
+  docsType: string;
+  title: string;
+}

--- a/apps/wiki/types/index.ts
+++ b/apps/wiki/types/index.ts
@@ -10,3 +10,4 @@ export type { default as ModalState } from "./modal.interface";
 export type { default as StyleVariantsType } from "./styleVariants.type";
 export type { default as TradeType } from "./trade.interface";
 export type { default as UserType } from "./user.interface";
+export type { default as HistoryListType } from "./historyList.interface";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "turbo run build",
+    "build": "dotenv -- turbo run build",
     "test": "turbo run test",
     "dev": "dotenv -- turbo dev",
     "lint": "turbo run lint",


### PR DESCRIPTION
## What
백엔드 단에서 변경된 사항에 맞게 DTO를 변경했습니다.

## How
- oauth 로그인에서 header로 던지던 authCode -> body, accessToken으로 변경
- refresh 토큰 로직 auth.api.ts 모듈로 이동
- history list dto에 docsType, title 추가정의로 편리한 속성 관리
- popular에서 slice로 자르던 데이터 -> 자르지 않고 조회
- docs에서 create, delete 키워드 api 라우터에서 삭제
- user에서 id 키워드 api 라우터에서 삭제